### PR TITLE
Fix issue #30 - when in source code view, saving blanks out canvas (requ...

### DIFF
--- a/src/gridmanager.js
+++ b/src/gridmanager.js
@@ -1148,10 +1148,25 @@
          * @returns null  
          */
         gm.cleanup =  function(){  
-          // cache canvas
-          var canvas=gm.$el.find("#" + gm.options.canvasId);
+          
+          var canvas,
+              content;
+              
+              // cache canvas
+              canvas = gm.$el.find("#" + gm.options.canvasId);
+
+              /**
+               * Determine the current edit mode and get the content based upon the resultant
+               * context to prevent content in source mode from being lost on save, as such:
+               *
+               * edit mode (source): canvas.find('textarea').val()
+               * edit mode (visual): canvas.html()
+               */
+              content = gm.mode !== "visual" ? canvas.find('textarea').val() : canvas.html();
+
               // Clean any temp class strings
-              canvas.html(gm.cleanSubstring(gm.options.classRenameSuffix, canvas.html(), ''));
+              canvas.html(gm.cleanSubstring(gm.options.classRenameSuffix, content, ''));
+              
               // Clean column markup
               canvas.find(gm.options.colSelector)
                   .removeAttr("style")


### PR DESCRIPTION
Problem: when in source code view, saving empties textarea.

`gm.cleanup` always assumed that it was dealing with the canvas element in visual mode but did not take into account that when saving from source code view that the content must come from the value of the textarea itself.

A simple check for the edit context prior to replacing the html of the canvas element takes care of this problem.

Note: only read your guidelines for contributing after committing my change, so this PR is in lieu of unit tests other than my physical test verifications. In light of the relatively simple nature of the fix, would you still consider this PR without the unit tests? Any further commits will be in accordance with the guidelines.
